### PR TITLE
Feature: backend users profile endpoints improved

### DIFF
--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -6,6 +6,9 @@ import { AppModule } from './app.module';
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 	app.useGlobalPipes(new ValidationPipe({ whitelist: true, }));
+	app.enableCors({
+		origin: 'http://localhost:3001'
+	  });
 
 	const swaggerConfig = new DocumentBuilder()
 		.setTitle('PostgreSQL API')

--- a/back/src/user/dto/user-profile.dto.ts
+++ b/back/src/user/dto/user-profile.dto.ts
@@ -1,9 +1,13 @@
 import { IsNotEmpty, IsString, isEmpty } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger"
+import { File } from "buffer";
 
 export class UserProfileDto {
 	@ApiProperty()
 	@IsString()
 	@IsNotEmpty()
 	nick: string
+
+	@ApiProperty()
+	file: File
 }

--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -33,21 +33,13 @@ export class UserController {
 	}
 
 	/*
-	 * Set / update user profile data
+	 * Set / update user profile data and profile picture
 	*/
 	@Put('profile')
 	@ApiBody({ type: UserProfileDto })
-	async updateProfileData(@GetJwt('sub') userId: number, @Body() dto: UserProfileDto) {
-		return this.userService.updateProfileData(userId, dto);
-	}
-
-	/*
-	 * Set / update user profile picture
-	*/
-	@Post('profile')
 	@UseInterceptors(FileInterceptor('file', saveProfileImageToStorage))
-	async uploadProfilePicture(@GetJwt('sub') userId: number, @UploadedFile() file?: Express.Multer.File) {
-		return this.userService.uploadProfilePicture(userId, file);
+	async updateProfileData(@GetJwt('sub') userId: number, @Body() dto: UserProfileDto, @UploadedFile() file?: Express.Multer.File) {
+		return this.userService.updateProfileData(userId, dto, file);
 	}
 
 	/*

--- a/back/src/utils/image-storage.ts
+++ b/back/src/utils/image-storage.ts
@@ -1,8 +1,9 @@
 import { diskStorage } from "multer";
 import { v4 as uuidv4 } from "uuid";
 import path = require('path');
+import { BadRequestException } from '@nestjs/common';
 
-;
+
 export const saveProfileImageToStorage = {
 	storage: diskStorage({
 		destination: './uploads/avatars',
@@ -15,7 +16,11 @@ export const saveProfileImageToStorage = {
 	fileFilter: (req, file, cb) => {
 		const allowedMimeTypes = ['image/jpg', 'image/jpeg', 'image/png'];
 
-		allowedMimeTypes.includes(file.mimetype) ? cb(null, true) : cb(null, false);
+		if (allowedMimeTypes.includes(file.mimetype)) {
+			cb(null, true);
+		} else {
+			cb(new BadRequestException('File must be a png, jpg/jpeg.'), false);
+		}
 	},
 	limits: {
 		fileSize: 5 * 1024 * 1024, // 5MB

--- a/back/test/app.e2e-spec.ts
+++ b/back/test/app.e2e-spec.ts
@@ -5,6 +5,8 @@ import { AppModule } from '../src/app.module';
 import { AuthDto } from '../src/auth/dto';
 import { PrismaService } from '../src/prisma/prisma.service';
 import { EditUserDto, UserProfileDto } from '../src/user/dto';
+import { readFileSync } from "fs";
+import { File } from "buffer";
 
 describe('App e2e', () => {
 	let app: INestApplication;
@@ -216,7 +218,7 @@ describe('App e2e', () => {
 			});
 		});
 		describe('updateProfileData', () => {
-			const dto: UserProfileDto = {
+			const dto = {
 				nick: "karisti"
 			}
 			it('should update user profile data', () => {
@@ -248,37 +250,6 @@ describe('App e2e', () => {
 						Authorization: '',
 					})
 					.withBody(dto)
-					.expectStatus(401)
-			});
-		});
-		describe('uploadProfilePicture', () => {
-			it('should throw 400 if picture not provided', () => {
-				return pactum
-					.spec()
-					.post('/users/profile')
-					.withHeaders({
-						Authorization: 'Bearer $S{userAt}',
-					})
-					.expectStatus(400)
-			});
-			/*
-			it('should throw 404 if user not found', () => {
-				return pactum
-					.spec()
-					.post('/users/profile')
-					.withHeaders({
-						Authorization: 'Bearer $S{userAtDel}',
-					})
-					.expectStatus(404)
-			});
-			*/
-			it('should throw 401 if jwt token not provided', () => {
-				return pactum
-					.spec()
-					.post('/users/profile')
-					.withHeaders({
-						Authorization: '',
-					})
 					.expectStatus(401)
 			});
 		});


### PR DESCRIPTION
Se ha mejorado el funcionamiento de los endpoints /users/profile.
- Ahora PUT /users/profile puede actualizar nick (obligatorio enviarlo siempre) y la foto de perfil en la misma petición.
- Se elimina el endpoint POST /users/profile y sus tests, ya que se utilizará el PUT mencionado anteriormente.
- Se mejora image-storage para controlar también el error de tipos de archivos dentro de el.

Además, hemos añadido enableCors que permite peticiones de nuestro frontend (desde http://localhost:3001). Por ahora hay que levantar primero el backend y después el front para que nos diga si queremos levantar el front en otro puerto que no sea el 3000, entonces lo levantará en el 3001. Sino, cambiar el puerto en main.ts del backend.