### PR TITLE
Feature: backend users profile GET and nick checks

### DIFF
--- a/back/prisma/migrations/20230516192629_default_avatar_uri/migration.sql
+++ b/back/prisma/migrations/20230516192629_default_avatar_uri/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `avatarUri` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "avatarUri" SET NOT NULL,
+ALTER COLUMN "avatarUri" SET DEFAULT 'default.jpg';

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
     firstName String?
     lastName  String?
 
-    avatarUri String?
+    avatarUri String @default("default.jpg")
     status    String @default("offline")
 
     score       Int      @default(0)

--- a/back/src/user/dto/index.ts
+++ b/back/src/user/dto/index.ts
@@ -1,4 +1,5 @@
 //Barrel Export
 
 export * from './edit-user.dto';
+export * from './user-profile-update.dto';
 export * from './user-profile.dto';

--- a/back/src/user/dto/user-profile-update.dto.ts
+++ b/back/src/user/dto/user-profile-update.dto.ts
@@ -1,8 +1,9 @@
 import { IsNotEmpty, MinLength, MaxLength } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger"
+import { File } from "buffer";
 import { IsNick } from '../../utils/decorators/is-nick.decorator';
 
-export class UserProfileDto {
+export class UserProfileUpdateDto {
 	@ApiProperty()
 	@IsNotEmpty()
 	@MinLength(3)
@@ -11,5 +12,5 @@ export class UserProfileDto {
 	nick: string
 
 	@ApiProperty()
-	avatarUri: string
+	file: File
 }

--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, UseGuards, Patch, Body, Delete, Post, UseInterceptors,
 import { ApiBody, ApiBearerAuth } from "@nestjs/swagger"
 import { JwtGuard } from "../auth/guard";
 import { GetJwt } from "../auth/decorator";
-import { EditUserDto, UserProfileDto } from "./dto";
+import { EditUserDto, UserProfileUpdateDto } from "./dto";
 import { UserService } from "./user.service";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { saveProfileImageToStorage } from "../utils/image-storage"
@@ -33,12 +33,20 @@ export class UserController {
 	}
 
 	/*
+	 * Get user profile data
+	*/
+	@Get('profile')
+	async getProfile(@GetJwt('sub') userId: number) {
+		return this.userService.getProfile(userId);
+	}
+
+	/*
 	 * Set / update user profile data and profile picture
 	*/
 	@Put('profile')
-	@ApiBody({ type: UserProfileDto })
+	@ApiBody({ type: UserProfileUpdateDto })
 	@UseInterceptors(FileInterceptor('file', saveProfileImageToStorage))
-	async updateProfileData(@GetJwt('sub') userId: number, @Body() dto: UserProfileDto, @UploadedFile() file?: Express.Multer.File) {
+	async updateProfileData(@GetJwt('sub') userId: number, @Body() dto: UserProfileUpdateDto, @UploadedFile() file?: Express.Multer.File) {
 		return this.userService.updateProfileData(userId, dto, file);
 	}
 

--- a/back/src/utils/decorators/is-nick.decorator.ts
+++ b/back/src/utils/decorators/is-nick.decorator.ts
@@ -1,0 +1,24 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+
+export function IsNick(validationOptions?: ValidationOptions) {
+	return function (object: Object, propertyName: string) {
+		registerDecorator({
+			name: 'isNick',
+			target: object.constructor,
+			propertyName: propertyName,
+			options: validationOptions,
+			validator: {
+				validate(value: any, args: ValidationArguments) {
+				const nickRegex = /^[a-zA-Z0-9-_]+$/; // Regular expression for nickname validation
+				if (typeof value !== 'string' || !nickRegex.test(value)) {
+					return false;
+				}
+				return true;
+				},
+				defaultMessage(args: ValidationArguments) {
+				return `${args.property} must be a valid nickname consisting of letters, numbers, hyphens, and underscores.`;
+				},
+			},
+		});
+	};
+}

--- a/back/test/app.e2e-spec.ts
+++ b/back/test/app.e2e-spec.ts
@@ -4,7 +4,7 @@ import * as pactum from 'pactum';
 import { AppModule } from '../src/app.module';
 import { AuthDto } from '../src/auth/dto';
 import { PrismaService } from '../src/prisma/prisma.service';
-import { EditUserDto, UserProfileDto } from '../src/user/dto';
+import { EditUserDto, UserProfileUpdateDto } from '../src/user/dto';
 import { readFileSync } from "fs";
 import { File } from "buffer";
 
@@ -215,6 +215,39 @@ describe('App e2e', () => {
 						Authorization: 'Bearer $S{userAtDel}',
 					})
 					.expectStatus(404)
+			});
+		});
+		describe('getProfileData', () => {
+			const dto = {
+				nick: "testuser"
+			}
+			it('should get user profile', () => {
+				return pactum
+					.spec()
+					.get('/users/profile')
+					.withHeaders({
+						Authorization: 'Bearer $S{userAt}',
+					})
+					.expectStatus(200)
+					.expectBodyContains(dto.nick)
+			});
+			it('should throw 404 if user not found', () => {
+				return pactum
+					.spec()
+					.get('/users/profile')
+					.withHeaders({
+						Authorization: 'Bearer $S{userAtDel}',
+					})
+					.expectStatus(404)
+			});
+			it('should throw 401 if jwt token not provided', () => {
+				return pactum
+					.spec()
+					.get('/users/profile')
+					.withHeaders({
+						Authorization: '',
+					})
+					.expectStatus(401)
 			});
 		});
 		describe('updateProfileData', () => {


### PR DESCRIPTION
Se mejora el funcionamiento de profile:
- Se añade "default.jpg" como default avatarUri en el esquema de prisma.
- Se añade el endpoint GET /users/profile.
- Se añade decorador para validar nick (entre 3-10 carácteres que pueden ser letras, números, "-" o "_".
- Se mejora mensaje de error de nick duplicado.
- Se modifican DTOs para los dos casos posibles actualmente (nick + archivo / nick + uri de archivo).