### PR TITLE
Fix: user status string changed to user isOnline boolean

### DIFF
--- a/back/prisma/migrations/20230521122818_user_status_changed_to_user_is_online/migration.sql
+++ b/back/prisma/migrations/20230521122818_user_status_changed_to_user_is_online/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "status",
+ADD COLUMN     "isOnline" BOOLEAN NOT NULL DEFAULT false;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
   lastName  String?
 
   avatarUri String  @default("default.jpg")
-  status    String  @default("offline")
+  isOnline  Boolean @default(false)
   isInGame  Boolean @default(false)
 
   friendsUser        Friend[] @relation("FriendsUser")

--- a/back/src/friend/friend.service.ts
+++ b/back/src/friend/friend.service.ts
@@ -66,10 +66,10 @@ export class FriendService {
 
 		const friends = user.friendsUser;
 
-		const friendList: { nick: string; avatarUri: string; status: string }[] = friends.map((friend) => ({
+		const friendList: { nick: string; avatarUri: string; isOnline: boolean }[] = friends.map((friend) => ({
 			nick: friend.friend.nick,
 			avatarUri: friend.friend.avatarUri,
-			status: friend.friend.status,
+			isOnline: friend.friend.isOnline,
 		}));
 
 		return friendList;

--- a/back/src/user/user-status.gateway.ts
+++ b/back/src/user/user-status.gateway.ts
@@ -33,7 +33,7 @@ export class UserGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 			return;
 		}
 
-		const user = await this.userService.setUserStatus(userId, 'online');
+		const user = await this.userService.setUserStatus(userId, true);
 		if (user == null)
 		{
 			client.disconnect();
@@ -51,7 +51,7 @@ export class UserGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 			return;
 		}
 
-		const user = await this.userService.setUserStatus(userId, 'offline');
+		const user = await this.userService.setUserStatus(userId, false);
 		if (user == null)
 		{
 			client.disconnect();

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -198,14 +198,14 @@ export class UserService {
 	/*
 	 * Set user status (online / offline)
 	*/
-	async setUserStatus(userId: number, status: string): Promise<any> {
+	async setUserStatus(userId: number, isOnline: boolean): Promise<any> {
 		try {
 			const user = await this.prisma.user.update({
 				where: {
 					id: userId
 				},
 				data: {
-					status: status
+					isOnline: isOnline
 				},
 			});
 			delete user.hash;


### PR DESCRIPTION
Se modifica la forma en la que se guarda el estado (conectado / desconectado) del usuario. Ahora se utiliza un booleano isOnline en vez de un string de status genérico como se planteó al principio.