### PR TITLE
[BUGFIX:PONG] Front-end game crash due to small resize singularity fi…

### DIFF
--- a/srcs/front/src/pages/pong/pong.alt.ts
+++ b/srcs/front/src/pages/pong/pong.alt.ts
@@ -336,6 +336,15 @@ class PongAlt
             height: Math.round(newCanvasHeight)
         }
 
+        // Add minimum size constraints
+        const minWidth = this.referenceResolution.width * 0.5;
+        const minHeight = this.referenceResolution.height * 0.5;
+        if (newCanvasWidth < minWidth || newCanvasHeight < minHeight)
+        {
+            // Skip resizing the canvas if below the minimum size
+            return;
+        }
+
         // Save previous canvas resolution
         const prevCanvasResolution: Resolution = {
             width: this.canvas.width,

--- a/srcs/front/src/pages/pong/pong.original.ts
+++ b/srcs/front/src/pages/pong/pong.original.ts
@@ -314,6 +314,15 @@ class Pong
             height: Math.round(newCanvasHeight)
         }
 
+        // Add minimum size constraints
+        const minWidth = this.referenceResolution.width * 0.5;
+        const minHeight = this.referenceResolution.height * 0.5;
+        if (newCanvasWidth < minWidth || newCanvasHeight < minHeight)
+        {
+            // Skip resizing the canvas if below the minimum size
+            return;
+        }
+
         // Save previous canvas resolution
         const prevCanvasResolution: Resolution = {
             width: this.canvas.width,
@@ -339,10 +348,11 @@ class Pong
         {
             if (this.gameState)
             {
-                // Physics update will probably need to be behind a sync check once websocket implemented
                 this.remoteUpdate();
+                // For predictive implementation
                 //this.physicsUpdate();
                 this.gameState = null;
+                // For predictive implementation
                 // this.scoreUpdate();
                 this.clearScreen();
                 this.drawables.forEach((drawable) => {


### PR DESCRIPTION
…xed.

A bug caused the game's rendering engine to enter an undefined behaviour loop when the canvas was resized to be extremely small. I am fairly certain this is because at some point the floats to calculate rescales would have been less than float epsilon, converted to 0, and then could no longer be rescaled upwards. The fix is simply a lower limit on canvas size defined as one half the reference resolution.